### PR TITLE
Change from nvidia-docker to plain docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docker-build:
 		-t ${DOCKER_IMAGE} .
 
 docker-run-test-sample:
-	nvidia-docker run --name panoptic --rm \
+	docker run --name panoptic --rm --gpus all \
 		-e DISPLAY=${DISPLAY} \
 		-v ${PWD}:${WORKSPACE} \
 		-v /tmp/.X11-unix:/tmp/.X11-unix \
@@ -50,7 +50,7 @@ docker-run-test-sample:
 		--pretrained-weight cvpr_realtime_pano_cityscapes_standalone_no_prefix.pth"
 
 docker-start:
-	nvidia-docker run --name panoptic --rm \
+	docker run --name panoptic --rm --gpus all \
 		-e DISPLAY=${DISPLAY} \
 		-v ${PWD}:${WORKSPACE} \
 		-v /tmp/.X11-unix:/tmp/.X11-unix \
@@ -63,4 +63,4 @@ docker-start:
 		-it \
 		${DOCKER_OPTS} \
 		${DOCKER_IMAGE} && \
-		nvidia-docker exec -it panoptic bash
+		docker exec -it panoptic bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --allow-downgrades --allow-change-held-
     libnccl-dev=${NCCL_VERSION} \
     libjpeg-dev \
     libpng-dev \
+    libgl1-mesa-glx \
     python${PYTHON_VERSION} \
     python${PYTHON_VERSION}-dev \
     python3-tk \


### PR DESCRIPTION
When using the latest version from NVIDIA Docker, the command `nvidia-docker` is deprecated.
Instead, one is supposed to use regular `docker` with the `--gpus` option.

This also adds `libgl1-mesa-glx` in the docker container for fixing issue #9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tri-ml/realtime_panoptic/10)
<!-- Reviewable:end -->
